### PR TITLE
EntityService::ParsePcapHelper::ParseBinary を実装

### DIFF
--- a/proj/packetentity/src/EntityService.cpp
+++ b/proj/packetentity/src/EntityService.cpp
@@ -96,9 +96,7 @@ StackableEntityPtr EntityService::ParsePcap(const struct pcap_pkthdr *const head
 {
     auto packet_length = header->caplen;
 
-    // TODO Binary 以外のエンティティを生成する
-    auto binaryEntityPtr = std::make_shared<BinaryEntity>(packet_length);
-    memcpy(binaryEntityPtr->Data->data(), packet, packet_length);
+    auto binaryEntityPtr = ParsePcapHelper::Parse(packet, packet_length);
 
     auto absoluteEntityPtr = std::make_shared<AbsoluteEntity>();
     auto timestampNs = header->ts.tv_sec * 1000000000 + header->ts.tv_usec * 1000;

--- a/proj/packetentity/src/EntityService.hpp
+++ b/proj/packetentity/src/EntityService.hpp
@@ -38,6 +38,17 @@ class EntityService
     /// @param filepath ファイルパス
     /// @return エンティティの配列
     static std::vector<StackableEntityPtr> ParsePcap(const std::filesystem::path &filepath);
+
+  private:
+    class ParsePcapHelper
+    {
+      public:
+        static StackableEntityPtr Parse(const uint8_t *packet, std::size_t length);
+        static StackableEntityPtr ParseEthernet(const uint8_t *packet, std::size_t length);
+        static StackableEntityPtr ParseIpv4(const uint8_t *packet, std::size_t length);
+        static StackableEntityPtr ParseUdp(const uint8_t *packet, std::size_t length);
+        static StackableEntityPtr ParseBinary(const uint8_t *packet, std::size_t length);
+    };
 };
 } // namespace PacketEntity
 

--- a/proj/packetentity/src/EntityService/ParsePcapHelper.cpp
+++ b/proj/packetentity/src/EntityService/ParsePcapHelper.cpp
@@ -1,0 +1,36 @@
+#include <EntityService.hpp>
+#include <net/ethernet.h>
+
+namespace PacketEntity
+{
+StackableEntityPtr EntityService::ParsePcapHelper::Parse(const uint8_t *packet, std::size_t length)
+{
+    auto entityPtr = ParseBinary(packet, length);
+    return entityPtr;
+}
+
+StackableEntityPtr EntityService::ParsePcapHelper::ParseEthernet(const uint8_t *packet, std::size_t length)
+{
+    // TODO
+    throw std::runtime_error("Not implemented");
+}
+
+StackableEntityPtr EntityService::ParsePcapHelper::ParseIpv4(const uint8_t *packet, std::size_t length)
+{
+    // TODO
+    throw std::runtime_error("Not implemented");
+}
+
+StackableEntityPtr EntityService::ParsePcapHelper::ParseUdp(const uint8_t *packet, std::size_t length)
+{
+    // TODO
+    throw std::runtime_error("Not implemented");
+}
+
+StackableEntityPtr EntityService::ParsePcapHelper::ParseBinary(const uint8_t *packet, std::size_t length)
+{
+    auto binaryEntityPtr = std::make_shared<BinaryEntity>(length);
+    memcpy(binaryEntityPtr->Data->data(), packet, length);
+    return binaryEntityPtr;
+}
+} // namespace PacketEntity


### PR DESCRIPTION
#47

- `EntityService::ParsePcapHelper::ParseBinary` を実装
- `EntityService::ParsePcap` から `EntityService::ParsePcapHelper::Parse()` を呼ぶように修正