### PR TITLE
IHL によるヘッダの可変長に対応する

### DIFF
--- a/proj/packet/src/Ipv4.hpp
+++ b/proj/packet/src/Ipv4.hpp
@@ -38,6 +38,9 @@ class Ipv4 : public Stackable
     Utility::ObservableProperty<uint16_t> Flags;
 
     /// @brief フラグメントオフセット
+    Utility::ObservableProperty<uint16_t> FragmentOffset;
+
+    /// @brief TTL
     Utility::ObservableProperty<uint8_t> Ttl;
 
     /// @brief プロトコル

--- a/proj/packetentity/src/EntityService.cpp
+++ b/proj/packetentity/src/EntityService.cpp
@@ -96,13 +96,13 @@ StackableEntityPtr EntityService::ParsePcap(const struct pcap_pkthdr *const head
 {
     auto packet_length = header->caplen;
 
-    auto binaryEntityPtr = ParsePcapHelper::Parse(packet, packet_length);
+    auto entityPtr = ParsePcapHelper::Parse(packet, packet_length);
 
     auto absoluteEntityPtr = std::make_shared<AbsoluteEntity>();
     auto timestampNs = header->ts.tv_sec * 100'0000'000 + header->ts.tv_usec * 1000;
     absoluteEntityPtr->TimestampNs = timestampNs;
 
-    absoluteEntityPtr->Stack.Value(binaryEntityPtr);
+    absoluteEntityPtr->Stack.Value(entityPtr);
 
     return absoluteEntityPtr;
 }


### PR DESCRIPTION
#41
他，IPv4 解析処理の不具合を修正
具体的な拡張ヘッダの解析は未対応 (#40 のタスク)