### PR TITLE
ReadOnlyObservableProperty を実装

### DIFF
--- a/proj/utility/src/ObservableProperty.hpp
+++ b/proj/utility/src/ObservableProperty.hpp
@@ -1,10 +1,14 @@
 #ifndef UTILITY__NOTIFY_PROPERTY_HPP
 #define UTILITY__NOTIFY_PROPERTY_HPP
 
+#include <memory>
 #include <functional>
 
 namespace Utility
 {
+template <typename T> class ObservableProperty;
+template <typename T> using ObservablePropertyPtr = std::shared_ptr<ObservableProperty<T>>;
+
 /// @brief 値の変更通知を提供可能なプロパティ
 /// @tparam T 値の型
 /// @details 値が変化したかどうかによらず Value を Set されると Notify が呼ばれる．

--- a/proj/utility/src/ReadOnlyObservableProperty.hpp
+++ b/proj/utility/src/ReadOnlyObservableProperty.hpp
@@ -5,7 +5,41 @@
 
 namespace Utility
 {
-// TODO ReadOnlyObservableProperty を実装する
+template <typename T> class ReadOnlyObservableProperty;
+template <typename T> using ReadOnlyObservablePropertyPtr = std::shared_ptr<ReadOnlyObservableProperty<T>>;
+
+/// @brief 値の変更通知を提供可能な読み取り専用のプロパティ
+/// @tparam T 値の型
+/// @details コンストラクタで ObservableProperty を受け取り，そのインスタンスの変化を通知する．
+template <typename T> class ReadOnlyObservableProperty
+{
+  public:
+    ReadOnlyObservableProperty() = delete;
+    ReadOnlyObservableProperty(ObservablePropertyPtr propertyPtr)
+    {
+        if (propertyPtr == nullptr)
+        {
+            throw std::runtime_error("Null pointer is not allowed.");
+        }
+
+        _PropertyPtr = propertyPtr;
+    }
+
+    T Value() const
+    {
+        return _Property->Value();
+    }
+
+    /// @brief 値が変更されたときに呼ばれるコールバックを登録する．
+    /// @param callback コールバック
+    void RegisterCallback(std::function<void(T, T)> callback)
+    {
+        _Property->RegisterCallback(callback);
+    }
+
+  private:
+    ObservablePropertyPtr _PropertyPtr;
+};
 } // namespace Utility
 
 #endif


### PR DESCRIPTION
#23 
ObservableProperty をうけとる．
ただし，ObservableProperty のライフタイムを管理できないので shared_ptr とした．